### PR TITLE
Don't cache `specifierToClasses` entries across multiple files

### DIFF
--- a/lib/rules/common/cache.ts
+++ b/lib/rules/common/cache.ts
@@ -92,7 +92,7 @@ export interface ProcessedMemberExpression {
 /** This class is used to cache the results of processing a css file */
 export class Cache {
   private static baseFilenameToClasses: BaseFilenameToClasses = {}
-  private static specifierToClasses: SpecifierToClasses = {}
+  private specifierToClasses: SpecifierToClasses = {}
   private settings: Settings
   private parser: Parser
 
@@ -103,12 +103,12 @@ export class Cache {
   constructor(context: Rule.RuleContext) {
     this.settings = new Settings(context)
     this.parser = new Parser(this.settings)
+    this.specifierToClasses = {}
   }
 
   /** Clear the cache */
   static clear(): void {
     Cache.baseFilenameToClasses = {}
-    Cache.specifierToClasses = {}
   }
 
   /**
@@ -159,7 +159,7 @@ export class Cache {
         ? Cache.baseFilenameToClasses[baseFilename].classes
         : this.parser.parse(filename)
     if (specifier) {
-      Cache.specifierToClasses[specifier] = {
+      this.specifierToClasses[specifier] = {
         baseFilename,
         classes,
       }
@@ -193,11 +193,11 @@ export class Cache {
     }
 
     const objectName = (node.object as ESTree.Identifier).name
-    if (Cache.specifierToClasses[objectName] === undefined) {
+    if (this.specifierToClasses[objectName] === undefined) {
       return null
     }
 
-    const { baseFilename, classes } = Cache.specifierToClasses[objectName]
+    const { baseFilename, classes } = this.specifierToClasses[objectName]
     const className = node.computed
       ? (node.property as ESTree.Literal).value
       : (node.property as ESTree.Identifier).name

--- a/test/rules/common/cache.test.ts
+++ b/test/rules/common/cache.test.ts
@@ -140,13 +140,15 @@ describe("Cache", () => {
   })
 
   describe("processMemberExpression", () => {
+    let cache: Cache
+
     const baseFilename = "test.css"
     const specifier = "styles"
     const classes = new Set(["class1", "class2", "class3"])
 
     beforeEach(() => {
+      cache = buildCache()
       // warm the cache
-      const cache = buildCache()
       const node = buildImportDeclaration(baseFilename, [
         buildImportDefaultSpecifier(specifier),
       ])
@@ -156,20 +158,17 @@ describe("Cache", () => {
     })
 
     test("improper node", () => {
-      const cache = buildCache()
       const node = ({ type: "WrongNode" } as unknown) as ESTree.Node
       expect(cache.processMemberExpression(node)).toBeNull()
     })
 
     test("uninteresting variable", () => {
-      const cache = buildCache()
       const node = buildMemberExpression("unknownVariable", "property", false)
       expect(cache.processMemberExpression(node)).toBeNull()
     })
 
     test("computed variable", () => {
       const className = "class1"
-      const cache = buildCache()
       const node = buildMemberExpression("styles", className, true)
       const result = cache.processMemberExpression(node)
       expect(result).not.toBeNull()
@@ -181,7 +180,6 @@ describe("Cache", () => {
 
     test("non-computed variable", () => {
       const className = "class1"
-      const cache = buildCache()
       const node = buildMemberExpression("styles", className, false)
       const result = cache.processMemberExpression(node)
       expect(result).not.toBeNull()


### PR DESCRIPTION
Hi. 

`specifierToClasses` being static / global is okay in many cases, because these lines overwrite the cache entry (if one existed from a previous file) for a specifier name (like `Styles` in `import Styles from 'file.css'`) when processing an import declaration: https://github.com/bmatcuk/eslint-plugin-postcss-modules/blob/5e8353c25368eabcb1bcd0e4748683a7c83fb6d5/lib/rules/common/cache.ts#L161-L166

However, there are cases where these lines don't run -- for example, if processing the import declaration returned early: https://github.com/bmatcuk/eslint-plugin-postcss-modules/blob/5e8353c25368eabcb1bcd0e4748683a7c83fb6d5/lib/rules/common/cache.ts#L131-L139

For example: let's say `fileA.jsx` contains `import Styles from './fileA.css'` and `fileB.jsx` contains `import Styles from './fileB.scss'` (so processing the import declaration in `fileB.jsx` returns early.)

If `fileB.jsx` is linted after `fileA.jsx`, the cached entry from the previous file may be used.