### PR TITLE
Fix namespace imports

### DIFF
--- a/lib/rules/common/cache.ts
+++ b/lib/rules/common/cache.ts
@@ -141,7 +141,7 @@ export class Cache {
         explicitImports.push(spec)
       } else if (
         nodeIsImportDefaultSpecifier(spec) ||
-        nodeIsImportNamespaceSpecifier(node)
+        nodeIsImportNamespaceSpecifier(spec)
       ) {
         // import styles from '...'
         // import * as styles from '...'

--- a/test/rules/common/cache.test.ts
+++ b/test/rules/common/cache.test.ts
@@ -93,30 +93,57 @@ describe("Cache", () => {
       })
     })
 
-    test("cold cache", () => {
+    describe("cold cache", () => {
       const filename = "test.css"
       const specifier = "styles"
       const explicitImports = [buildImportSpecifier("class1")]
 
-      const cache = buildCache()
-      const node = buildImportDeclaration(filename, [
-        buildImportDefaultSpecifier(specifier),
-        ...explicitImports,
-      ])
-      parseMock.mockReturnValueOnce(parseResult)
+      let cache: Cache
+      beforeEach(() => {
+        cache = buildCache()
+      })
 
-      const result = cache.processImportDeclaration(node)
-      expect(parseMock).toHaveBeenCalledTimes(1)
-      expect(result).not.toBeNull()
-      expect(result).toHaveProperty("node", node)
-      expect(result).toHaveProperty(
-        "filename",
-        expect.stringMatching(new RegExp(`${filename}$$`))
-      )
-      expect(result).toHaveProperty("specifier", specifier)
-      expect(result).toHaveProperty("explicitImports", explicitImports)
-      expect(result).toHaveProperty("classes", classes)
-      expect(result).toHaveProperty("usedClasses", usedClasses)
+      test("default import", () => {
+        const node = buildImportDeclaration(filename, [
+          buildImportDefaultSpecifier(specifier),
+          ...explicitImports,
+        ])
+        parseMock.mockReturnValueOnce(parseResult)
+
+        const result = cache.processImportDeclaration(node)
+        expect(parseMock).toHaveBeenCalledTimes(1)
+        expect(result).not.toBeNull()
+        expect(result).toHaveProperty("node", node)
+        expect(result).toHaveProperty(
+          "filename",
+          expect.stringMatching(new RegExp(`${filename}$$`))
+        )
+        expect(result).toHaveProperty("specifier", specifier)
+        expect(result).toHaveProperty("explicitImports", explicitImports)
+        expect(result).toHaveProperty("classes", classes)
+        expect(result).toHaveProperty("usedClasses", usedClasses)
+      })
+
+      test("namespace import", () => {
+        const node = buildImportDeclaration(filename, [
+          buildImportNamespaceSpecifier(specifier),
+          ...explicitImports,
+        ])
+        parseMock.mockReturnValueOnce(parseResult)
+
+        const result = cache.processImportDeclaration(node)
+        expect(parseMock).toHaveBeenCalledTimes(1)
+        expect(result).not.toBeNull()
+        expect(result).toHaveProperty("node", node)
+        expect(result).toHaveProperty(
+          "filename",
+          expect.stringMatching(new RegExp(`${filename}$$`))
+        )
+        expect(result).toHaveProperty("specifier", specifier)
+        expect(result).toHaveProperty("explicitImports", explicitImports)
+        expect(result).toHaveProperty("classes", classes)
+        expect(result).toHaveProperty("usedClasses", usedClasses)
+      })
     })
 
     test("warm cache", () => {


### PR DESCRIPTION
Fixed a typo that was causing the plugin to ignore namespace imports like `import * as styles from './styles.module.css'`.