### PR TITLE
Only load deasync module if needed

### DIFF
--- a/lib/sync.ts
+++ b/lib/sync.ts
@@ -1,5 +1,3 @@
-import { loopWhile } from "deasync"
-
 export default <T>(promise: { then: Promise<T>["then"] }): T => {
   let done = false
   let result: T | null = null
@@ -16,6 +14,8 @@ export default <T>(promise: { then: Promise<T>["then"] }): T => {
     }
   )
 
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { loopWhile } = require("deasync")
   loopWhile(() => !done)
 
   if (err !== null) {


### PR DESCRIPTION
The `deasync` module is not compatible with Electron (https://github.com/abbr/deasync/issues/81), making it impossible to use this plugin with VSCode's ESLint plugin since it errors on load. But this module is only actually needed if an async postcss config is encountered, which is not the default. Moving the `require` call inside of the function body means that we don't load the module unless it's needed.

I was able to verify that the plugin works in VSCode after this change, but I'm not sure the best way to test this with the automated tests given that `deasync` also doesn't work in them. One option is to mock the `deasync` module and assert that it is/isn't called in the parser test.